### PR TITLE
fix so that intializeLog() won't break if login plugin is missing

### DIFF
--- a/src/spa/store/index.js
+++ b/src/spa/store/index.js
@@ -54,7 +54,8 @@ const farmModule = {
       const newLog = logFactory({
         type: logType,
         name: `Observation: ${curDateString} - ${curTimeString}`,
-        log_owner: rootState.user.name ? rootState.user.name : '',
+        // TODO: Try to decouple this further from the login plugin
+        log_owner: (rootState.user) ? rootState.user.name : '',
         timestamp: timestamp,
       });
       commit('addLogAndMakeCurrent', newLog);


### PR DESCRIPTION
If the SPA is loaded without the optional login dependency, this little bit would throw an error because it's looking for a property (`name`) of an undefined (`user`). This is a quick fix, which squashes the error, but in the long term we should probably consider better ways to decouple the login module's state from the SPA. Or perhaps better yet, we should consider reintegrating the login module's state (eg, all of `state.user`) back into the SPA, the same way we did with the `logs` state.