### PR TITLE
Fix logfactory

### DIFF
--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -4,9 +4,9 @@ export default {
 
   actions: {
 
-    createRecord ({commit, dispatch, rootstate}, newRecord) {
-      const tableName = newRecord.type
-      delete newRecord.local_id
+    createRecord ({commit, dispatch, rootstate}, newLog) {
+      const tableName = newLog.type;
+      const newRecord = logFactory(newLog);
       openDatabase()
       .then(function(db) {
         return makeTable(db, tableName, newRecord);

--- a/src/data/logFactory.js
+++ b/src/data/logFactory.js
@@ -1,11 +1,15 @@
-// A helper function for creating new log items with default properties
+/**
+  * A utility function for structuring logs within the data plugin,
+  * before storing in the database, posting to the server, or for
+  * otherwise rendering logs in a standard format.
+**/
 export function logFactory ({
-  // TODO: Owner should be identified by user id, once we have authentication
+  // Assign default properties or leave them as optional
   log_owner = '',
   notes = '',
   quantity = '',
-  id = null,
-  local_id = null,
+  id,
+  local_id,
   name = '',
   type = '',
   timestamp = '',
@@ -13,16 +17,24 @@ export function logFactory ({
   isCachedLocally = false,
   wasPushedToServer = false,
 } = {}) {
-  return {
+  let log = {
     log_owner,
     notes,
     quantity,
     id,
-    local_id,
     name,
     type,
     timestamp,
     done,
     isCachedLocally,
   };
+  // Only return the id property if one has already been assigned by the server, otherwise omit it so the server can assign a new one.
+  if (id) {
+    log.id = id;
+  };
+  // Only return the local_id property if one has already been assigned by WebSQL, otherwise let WebSQL assign a new one.
+  if (local_id) {
+    log.local_id = local_id;
+  };
+  return log;
 }

--- a/src/spa/store/logFactory.js
+++ b/src/spa/store/logFactory.js
@@ -11,6 +11,7 @@ export function logFactory ({
   timestamp = '',
   done = false,
   isCachedLocally = false,
+  wasPushedToServer = false
 } = {}) {
   return {
     log_owner,
@@ -23,5 +24,6 @@ export function logFactory ({
     timestamp,
     done,
     isCachedLocally,
+    wasPushedToServer
   };
 }


### PR DESCRIPTION
This fixes a bug where the `wasPushedToServer` property was getting scrubbed from logs in the SPA store, causing a SQL error in the data plugin. There are two problems with this, addressed in the 2 separate commits, respectively:

1. The Vuex store needs to include the property, because it will affect the view layer.
2. Even if the property wasn't included in the store, SPA data formatting shouldn't induce a SQL error; the data plugin needs to guarantee for itself that data has been properly formatted before trying to run SQL inserts.

See issue #16 